### PR TITLE
Fix #4: also accept non numbers as knooppuntnummer like W28

### DIFF
--- a/knooppunten.py
+++ b/knooppunten.py
@@ -87,7 +87,7 @@ def main():
 
     print("Statistics:")
     print("Nodes analyzed (external):", len(nodes_ext))
-    print("Nodes analyzed (OSM):", len(nodes_ext))
+    print("Nodes analyzed (OSM):", len(nodes_osm))
     print("Great matches (<1m):", len(great_matches))
     print("Good matches: (1-10m):", len(good_matches))
     print("Poor matches: (10-100m):", len(poor_matches))

--- a/osm_knooppunten/helper.py
+++ b/osm_knooppunten/helper.py
@@ -3,6 +3,9 @@ def is_number_valid(number):
     if number == "?" or number == "0" or number == "":
         return False
 
+    if isinstance(number, str) and len(number) == 3 and 'A' <= number[0] <= 'Z':
+        number = number[1:3]
+
     try:
         if int(number) < 1:
             return False


### PR DESCRIPTION
In some networks a knooppuntnumber is not a real number but something like W28. This PR also accept 3 letter codes with the first letter A till Z and the other 2 letters form a correct integer number.